### PR TITLE
66 move decorators from maybe result containers

### DIFF
--- a/tests/test_future_maybe.py
+++ b/tests/test_future_maybe.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.utils import add, add_async, get_async, is_even, is_even_async, set_async
 from tibia import mapping
-from tibia.future_maybe import FutureMaybe
+from tibia.future_maybe import FutureMaybe, safe, wraps
 from tibia.maybe import Empty, Maybe, Some
 from tibia.utils import identity_async
 
@@ -306,8 +306,11 @@ async def test_inspect_async(maybe: Maybe[dict], target: dict | None):
 )
 async def test_wraps(data: dict, target: Maybe[str | None]):
     maybe_get = FutureMaybe.wraps(get_async)
+    maybe_get_new = wraps(get_async)
 
-    assert (await maybe_get(data, "key")) == target
+    assert (
+        (await maybe_get(data, "key")) == (await maybe_get_new(data, "key")) == target
+    )
 
 
 @pytest.mark.asyncio
@@ -320,5 +323,8 @@ async def test_wraps(data: dict, target: Maybe[str | None]):
 )
 async def test_wraps_optional(data: dict, target: Maybe[str | None]):
     maybe_get = FutureMaybe.wraps_optional(get_async)
+    maybe_get_new = safe(get_async)
 
-    assert (await maybe_get(data, "key")) == target
+    assert (
+        (await maybe_get(data, "key")) == (await maybe_get_new(data, "key")) == target
+    )

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.utils import add, add_async, is_even, is_even_async, set_async
 from tibia import mapping
-from tibia.maybe import Empty, Maybe, Some, match_some
+from tibia.maybe import Empty, Maybe, Some, match_some, safe, wraps
 
 
 @pytest.mark.parametrize(
@@ -266,8 +266,9 @@ async def test_inspect_async(maybe: Maybe[dict], target: dict | None):
 )
 def test_wraps(data: dict, target: Maybe[str | None]):
     maybe_get = Maybe.wraps(dict.get)
+    maybe_get_new = wraps(dict.get)
 
-    assert maybe_get(data, "key") == target
+    assert maybe_get(data, "key") == maybe_get_new(data, "key") == target
 
 
 @pytest.mark.parametrize(
@@ -279,8 +280,9 @@ def test_wraps(data: dict, target: Maybe[str | None]):
 )
 def test_wraps_optional(data: dict, target: Maybe[str | None]):
     maybe_get = Maybe.wraps_optional(dict.get)
+    maybe_get_new = safe(dict.get)
 
-    assert maybe_get(data, "key") == target
+    assert maybe_get(data, "key") == maybe_get_new(data, "key") == target
 
 
 @pytest.mark.parametrize(

--- a/tibia/future_maybe.py
+++ b/tibia/future_maybe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import warnings
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Concatenate
 
@@ -143,6 +144,14 @@ class FutureMaybe[T]:
 
     @staticmethod
     def wraps[**P, R](fn: Callable[P, Awaitable[R]]) -> Callable[P, FutureMaybe[R]]:
+        warnings.simplefilter("always", DeprecationWarning)
+        warnings.warn(
+            "FutureMaybe.wraps will be deprecated in tibia@3.0.0, "
+            "use future_maybe.wraps instead",
+            DeprecationWarning,
+        )
+        warnings.simplefilter("default", DeprecationWarning)
+
         @functools.wraps(fn)
         def _wraps(*args: P.args, **kwargs: P.kwargs) -> FutureMaybe[R]:
             return FutureMaybe.from_value(fn(*args, **kwargs))
@@ -153,6 +162,14 @@ class FutureMaybe[T]:
     def wraps_optional[**P, R](
         fn: Callable[P, Awaitable[R | None]],
     ) -> Callable[P, FutureMaybe[R]]:
+        warnings.simplefilter("always", DeprecationWarning)
+        warnings.warn(
+            "FutureMaybe.wraps_optional will be deprecated in tibia@3.0.0, "
+            "use future_maybe.safe instead",
+            DeprecationWarning,
+        )
+        warnings.simplefilter("default", DeprecationWarning)
+
         @functools.wraps(fn)
         def _wraps_optional(*args: P.args, **kwargs: P.kwargs) -> FutureMaybe[R]:
             return FutureMaybe.from_optional(fn(*args, **kwargs))
@@ -300,3 +317,21 @@ async def inspect_async[T, **P](
     **kwargs: P.kwargs,
 ) -> m.Maybe[T]:
     return await m.inspect_async(await fm._internal, fn, *args, **kwargs)
+
+
+def wraps[**P, T](fn: Callable[P, Awaitable[T]]) -> Callable[P, FutureMaybe[T]]:
+    @functools.wraps(fn)
+    def _wraps(*args: P.args, **kwargs: P.kwargs) -> FutureMaybe[T]:
+        return FutureMaybe.from_value(fn(*args, **kwargs))
+
+    return _wraps
+
+
+def safe[**P, T](
+    fn: Callable[P, Awaitable[T | None]],
+) -> Callable[P, FutureMaybe[T]]:
+    @functools.wraps(fn)
+    def _safe(*args: P.args, **kwargs: P.kwargs) -> FutureMaybe[T]:
+        return FutureMaybe.from_optional(fn(*args, **kwargs))
+
+    return _safe

--- a/tibia/maybe.py
+++ b/tibia/maybe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import warnings
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Concatenate, cast
 
@@ -137,6 +138,13 @@ class Maybe[T]:
 
     @staticmethod
     def wraps[**P, R](fn: Callable[P, R]) -> Callable[P, Maybe[R]]:
+        warnings.simplefilter("always", DeprecationWarning)
+        warnings.warn(
+            "Maybe.wraps will be deprecated in tibia@3.0.0, use maybe.wraps instead",
+            DeprecationWarning,
+        )
+        warnings.simplefilter("default", DeprecationWarning)
+
         @functools.wraps(fn)
         def _wraps(*args: P.args, **kwargs: P.kwargs) -> Maybe[R]:
             return Some(fn(*args, **kwargs))
@@ -145,6 +153,14 @@ class Maybe[T]:
 
     @staticmethod
     def wraps_optional[**P, R](fn: Callable[P, R | None]) -> Callable[P, Maybe[R]]:
+        warnings.simplefilter("always", DeprecationWarning)
+        warnings.warn(
+            "Maybe.wraps_optional will be deprecated in tibia@3.0.0, "
+            "use maybe.safe instead",
+            DeprecationWarning,
+        )
+        warnings.simplefilter("default", DeprecationWarning)
+
         @functools.wraps(fn)
         def _wraps_optional(*args: P.args, **kwargs: P.kwargs) -> Maybe[R]:
             return Maybe.from_optional(fn(*args, **kwargs))
@@ -367,3 +383,19 @@ def match_some[**P, T](*fns: Callable[P, Maybe[T]]) -> Callable[P, Maybe[T]]:
         return _Empty
 
     return _match_some
+
+
+def wraps[**P, T](fn: Callable[P, T]) -> Callable[P, Maybe[T]]:
+    @functools.wraps(fn)
+    def _wraps(*args: P.args, **kwargs: P.kwargs) -> Maybe[T]:
+        return Some(fn(*args, **kwargs))
+
+    return _wraps
+
+
+def safe[**P, T](fn: Callable[P, T | None]) -> Callable[P, Maybe[T]]:
+    @functools.wraps(fn)
+    def _wraps(*args: P.args, **kwargs: P.kwargs) -> Maybe[T]:
+        return Maybe.from_optional(fn(*args, **kwargs))
+
+    return _wraps


### PR DESCRIPTION
- **feat[#66]: deprecate `Result` decorators, add func-based decorators**
- **feat[#66]: deprecate `FutureResult` decorators, add func-based**
- **feat[#66]: deprecate `Maybe` decorators, add func-based**
- **feat[#66]: deprecate `FutureMaybe` decorators, add func-based**
